### PR TITLE
Add secondary rounded button with icon after the text

### DIFF
--- a/Buttons/button_secondary_icon_rounded_after.html
+++ b/Buttons/button_secondary_icon_rounded_after.html
@@ -1,0 +1,6 @@
+<button href="#" class="flex items-center justify-center rounded-full border border-blue-700 bg-transparent py-3 pr-3 pl-6 font-medium text-blue-700 hover:border-transparent hover:bg-blue-500 hover:text-white">
+  Tag
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 28 24" stroke-width="2" stroke="currentColor" class="mx-2 h-6 w-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+  </svg>
+</button>


### PR DESCRIPTION
Here is the component I have built for issue #20 .
I have attached the screenshot for the same.
<img width="1438" alt="secondary rounded button with icon after the text" src="https://user-images.githubusercontent.com/55877612/195262578-6a9359bf-f295-4979-b17a-ffa5e4186b58.png">

Do let me know if any changes are to be made.